### PR TITLE
Add repo-sunsetter workflow for archiving repository

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,22 @@
+name: Archive repository
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run-repo-sunsetter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Run repo-sunsetter
+        id: archive
+        uses: DSACMS/repo-sunsetter@v1.0.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Add repo-sunsetter workflow for archiving repository

## Problem

We would like to archive this repository using `repo-sunsetter`

## Solution

This PR adds a GitHub workflow to use repo-sunsetter to archive the repository

## Result

With `repo-sunsetter` used in the archive workflow, we can prepare this repository for archival. It will send 2 PRs updating the README and code.json file as well as 1 issue that posts the archive review checklist