### PR TITLE
Archive: Enable maturity model tiers in archive workflow

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -20,3 +20,4 @@ jobs:
         uses: DSACMS/repo-sunsetter@v1.0.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          USE_MATURITY_MODEL_TIERS: "true"


### PR DESCRIPTION
## Archive: Enable maturity model tiers in archive workflow

## Problem

Oops I forgot to add maturity model tiers param to the archive workflow

## Solution

Add `USE_MATURITY_MODEL_TIERS`

## Result

The action should run successfully now